### PR TITLE
Add support for the trafficlight4

### DIFF
--- a/traffic_light/__main__.py
+++ b/traffic_light/__main__.py
@@ -2,7 +2,7 @@ import sys
 import argparse
 
 from traffic_light.error import TrafficLightError, MultipleTrafficLightsError
-from traffic_light.core import ClewareTrafficLight, State, Color
+from traffic_light.core import ClewareTrafficLight, State, Color, Direction
 
 
 def main(args=sys.argv[1:]):
@@ -22,6 +22,10 @@ def main(args=sys.argv[1:]):
     parser.add_argument('-a', '--all',
                         choices=["on", "off"],
                         help="Controlls all leds")
+    parser.add_argument('-d', '--direction',
+                        choices=["left", "front", "right", "back", "all"],
+                        default="all",
+                        help="Select the direction you want to actuate (requires a trafficlight4)")
     parser.add_argument('-adr', '--address',
                         type=int,
                         help="Specifies which traffic light should be used")
@@ -29,7 +33,7 @@ def main(args=sys.argv[1:]):
 
     if not vars(args)['all']:
         all_given_colors = [(k, v) for k, v in vars(args).items()
-                            if v is not None and k is not "address"]
+                            if v is not None and k not in ["direction", "address"]]
         if not all_given_colors:
             parser.print_help()
             return 1
@@ -42,9 +46,10 @@ def main(args=sys.argv[1:]):
     for color_name, state_name in all_given_colors:
         color = Color[color_name.upper()]
         state = State[state_name.upper()]
+        direction = Direction[vars(args)['direction'].upper()]
         address = vars(args)["address"]
         try:
-            ClewareTrafficLight(address).set_led(color, state)
+            ClewareTrafficLight(address).set_led(color, state, direction=direction)
         except MultipleTrafficLightsError as exc:
             print(exc, file=sys.stderr)
             ClewareTrafficLight.print_devices()

--- a/traffic_light/core.py
+++ b/traffic_light/core.py
@@ -1,4 +1,5 @@
 from enum import IntEnum
+from struct import pack
 
 import functools
 import usb.core
@@ -8,7 +9,9 @@ from traffic_light.error import TrafficLightError, MultipleTrafficLightsError
 
 CTRL_ENDPOINT = 0x02
 ID_VENDOR = 0x0d50
-ID_PRODUCT = 0x0008
+ID_PRODUCT_ORIGINAL = 0x0008
+ID_PRODUCT_SWITCH = 0x0030
+ID_PRODUCTS = (ID_PRODUCT_ORIGINAL, ID_PRODUCT_SWITCH)
 INTERFACE = 0
 
 
@@ -27,19 +30,14 @@ class ClewareTrafficLight:
     def __init__(self, address=None):
         if address:
             self.address = address
-            self.device = usb.core.find(
-                address=address,
-                idVendor=ID_VENDOR,
-                idProduct=ID_PRODUCT)
+            self.device = self.find_device(address=address)
         elif len(list(ClewareTrafficLight.find_devices())) > 1:
             raise MultipleTrafficLightsError(
                 "No address is given and there are multiple devices conected! "
                 "Use 'print_devices' to see a list of connected devices."
             )
         else:
-            self.device = usb.core.find(
-                idVendor=ID_VENDOR,
-                idProduct=ID_PRODUCT)
+            self.device = self.find_device()
         if self.device is None:
             raise TrafficLightError('Cleware traffic light not found!')
         self.reattach = False
@@ -59,10 +57,26 @@ class ClewareTrafficLight:
     @staticmethod
     def find_devices():
         """Returns the raw iterator of all found traffic lights"""
-        devices = usb.core.find(find_all=True, idVendor=ID_VENDOR, idProduct=ID_PRODUCT)
-        if devices:
-            return devices
-        return []
+        devices = []
+
+        for product_id in ID_PRODUCTS:
+            if devs := usb.core.find(find_all=True, idVendor=ID_VENDOR,
+                                     idProduct=product_id):
+                devices.extend(devs)
+
+        return devices
+
+    @classmethod
+    def find_device(self, address=None):
+        """Returns a traffic light device, located at the specified address"""
+
+        for product_id in ID_PRODUCTS:
+            kwargs = {"idVendor": ID_VENDOR, "idProduct": product_id}
+            if address is not None:
+                kwargs["address"] = address
+
+            if dev := usb.core.find(**kwargs):
+                return dev
 
     @staticmethod
     def print_devices():
@@ -77,6 +91,33 @@ class ClewareTrafficLight:
         usb_devices = ClewareTrafficLight.find_devices()
         return [ClewareTrafficLight(d.address) for d in usb_devices]
 
+    def _compute_led_payload(self, color, value):
+        if self.device.idProduct == ID_PRODUCT_ORIGINAL:
+            return [0x00, color, value]
+        elif self.device.idProduct == ID_PRODUCT_SWITCH:
+            # The traffic light v4 is acting like a switch. The switches' state
+            # are represented as a 16-bit bitfield where bit 0 represents the
+            # top-left LED, and all the following bits represent the next LED
+            # anticlockwise all the way to bit 11 which represents the state of
+            # the back-bottom LED.
+            #
+            # Updating the bitfield is done by setting every bit we
+            # want to update in the mask, then setting the wanted value in the
+            # value field. The final result will be equal to:
+            #
+            #     new_state = (state & ~mask) | value
+            #
+            # And here is the command one needs to set
+            # - action: 8bits <-- Command 11
+            # - value: 16 bits (big endian)
+            # - mask: 16 bits (big endian)
+            #
+            color_id = color % 0x10      # Red = 0, Yellow = 1, Green = 2
+            color_offset = color_id * 4  # Red = 0-3, Yellow = 4-7, Green = 8-11
+            return pack(">BHH", 11, (0xf << color_offset) * value, 0xf << color_offset)
+        else:
+            raise TrafficLightError("Unknown product ID")
+
     def set_led(self, color, value, timeout=1000):
         """Sets the given state and color of the attached traffic light
 
@@ -87,7 +128,8 @@ class ClewareTrafficLight:
         """
         try:
             self.detach()
-            self.device.write(CTRL_ENDPOINT, [0x00, color, value], timeout=timeout)
+            payload = self._compute_led_payload(color, value)
+            self.device.write(CTRL_ENDPOINT, payload, timeout=timeout)
         except Exception as exc:
             raise TrafficLightError(str(exc)) from exc
         finally:
@@ -109,4 +151,4 @@ class ClewareTrafficLight:
         return ("== Cleware Traffic Light ==\n"
                 "Address: {} \n"
                 "IdVendor: {} \n"
-                "IdProduct: {}".format(self.address, ID_VENDOR, ID_PRODUCT))
+                "IdProduct: {}".format(self.address, self.device.idVendor, self.device.idProduct))


### PR DESCRIPTION
Cleware stopped selling its older versions of the traffic light in favor of their newer version. The new version enables independent control of the LEDs in all directions (12 choices instead of 3), and is controlled using the "Switch" interface.

This Pull Request adds support for the new product ID, then adds support for directionality.