### PR TITLE
tests: use the original idProduct for the tests

### DIFF
--- a/test/core_test.py
+++ b/test/core_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import usb.core
 
-from traffic_light.core import ClewareTrafficLight, Color, State
+from traffic_light.core import ClewareTrafficLight, Color, State, ID_PRODUCT_ORIGINAL
 from traffic_light.error import TrafficLightError, MultipleTrafficLightsError
 
 
@@ -67,7 +67,7 @@ def test_should_fail_for_wrong_state_in_getattr(usb_find_mock):
 ])
 def test_should_turn_on_led(usb_find_mock, test_input, expected):
     # given
-    device_mock = mock.MagicMock()
+    device_mock = mock.MagicMock(idProduct=ID_PRODUCT_ORIGINAL)
     usb_find_mock.return_value = device_mock
     light = ClewareTrafficLight()
 

--- a/test/main_test.py
+++ b/test/main_test.py
@@ -1,9 +1,10 @@
 from traffic_light.__main__ import main
+from traffic_light.core import ID_PRODUCT_ORIGINAL
 from unittest import mock
 import pytest
 
 
-@mock.patch("usb.core.find")
+@mock.patch("usb.core.find", return_value=mock.MagicMock(idProduct=ID_PRODUCT_ORIGINAL))
 @pytest.mark.parametrize("test_input,expected", [
     (['--all', 'on'], 0),
     (['--all', 'off'], 0),
@@ -22,7 +23,7 @@ def test_should_fail_for_wrong_argument_and_value(test_input):
         main(test_input)
 
 
-@mock.patch("usb.core.find")
+@mock.patch("usb.core.find", return_value=mock.MagicMock(idProduct=ID_PRODUCT_ORIGINAL))
 @pytest.mark.parametrize("test_input,expected", [
     (['--red', 'on'], 0),
     (['--red', 'off'], 0),
@@ -46,7 +47,7 @@ def test_should_fail_for_no_given_color(test_input, expected):
     assert main(test_input) == expected
 
 
-@mock.patch("usb.core.find")
+@mock.patch("usb.core.find", return_value=mock.MagicMock(idProduct=ID_PRODUCT_ORIGINAL))
 def test_should_fail_for_multiple_lights_whitout_given_address(usb_find_mock):
     # given
     def side_effect(*args, **kwargs):
@@ -60,7 +61,7 @@ def test_should_fail_for_multiple_lights_whitout_given_address(usb_find_mock):
     assert main(["--red", "on"]) == 1
 
 
-@mock.patch("usb.core.find")
+@mock.patch("usb.core.find", return_value=mock.MagicMock(idProduct=ID_PRODUCT_ORIGINAL))
 def test_should_fail_for_no_connected_light(usb_find_mock):
     # given
     usb_find_mock.return_value = None


### PR DESCRIPTION
When I added support for the trafficlight4, I accidentally broke the tests... This commit fixes test execution, while future commit will add testing for the features I introduced.

Fixes: 01fdd961dd (Add support for trafficlight4)